### PR TITLE
feat(ui): extend button helper for subtle icon buttons

### DIFF
--- a/frontend/ui/fields/number.tsx
+++ b/frontend/ui/fields/number.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Control, type FieldValues, type Path, useController } from 'react-hook-form';
 import { cn } from '@/ui/cn';
+import { buttonCls } from '@/ui/style';
 import { Minus, Plus } from 'lucide-react';
 
 type NumberFieldProps = Omit<
@@ -19,7 +20,12 @@ function NumberField({ name, onChange, disabled, value: inValue, min, max, ...pr
   const plus = React.useCallback(() => onChange(value + 1), [onChange, value]);
   return (
     <fieldset disabled={disabled} className="flex gap-2 relative">
-      <button type="button" className="text-accent-9 disabled:text-accent-7" disabled={disabled || value <= min} onClick={minus}>
+      <button
+        type="button"
+        className={buttonCls({ display: 'iconOnly', variant: 'subtle', size: 'icon' })}
+        disabled={disabled || value <= min}
+        onClick={minus}
+      >
         <Minus className="size-5" />
       </button>
       <input
@@ -37,7 +43,12 @@ function NumberField({ name, onChange, disabled, value: inValue, min, max, ...pr
           props.className,
         )}
       />
-      <button type="button" className="text-accent-9 disabled:text-accent-7" disabled={disabled || value >= max} onClick={plus}>
+      <button
+        type="button"
+        className={buttonCls({ display: 'iconOnly', variant: 'subtle', size: 'icon' })}
+        disabled={disabled || value >= max}
+        onClick={plus}
+      >
         <Plus className="size-5" />
       </button>
     </fieldset>

--- a/frontend/ui/forms/MyRegistrationForm.tsx
+++ b/frontend/ui/forms/MyRegistrationForm.tsx
@@ -8,6 +8,7 @@ import { TextAreaElement } from '@/ui/fields/textarea';
 import { FormError, useFormResult } from '@/ui/form';
 import { formatRegistrant } from '@/ui/format';
 import { SubmitButton } from '@/ui/submit';
+import { buttonCls } from '@/ui/style';
 import { Minus, Plus } from 'lucide-react';
 import * as React from 'react';
 import { useAsyncCallback } from 'react-async-hook';
@@ -87,7 +88,7 @@ export function MyRegistrationForm({ event, registration }: {
           <div key={trainer.id} className="flex flex-wrap gap-2">
             <button
               type="button"
-              className="text-accent-9 disabled:text-accent-7"
+              className={buttonCls({ display: 'iconOnly', variant: 'subtle', size: 'icon' })}
               onClick={() => changeLessonCount(-1, trainer)}
               disabled={fetching || !myLessons[trainer.id]}
             >
@@ -96,7 +97,7 @@ export function MyRegistrationForm({ event, registration }: {
             <div className="text-xl tabular-nums">{myLessons[trainer.id] ?? 0}x</div>
             <button
               type="button"
-              className="text-accent-9 disabled:text-accent-7"
+              className={buttonCls({ display: 'iconOnly', variant: 'subtle', size: 'icon' })}
               onClick={() => changeLessonCount(1, trainer)}
               disabled={fetching || (trainer.lessonsRemaining ?? 0) < 1}
             >

--- a/frontend/ui/forms/NewRegistrationForm.tsx
+++ b/frontend/ui/forms/NewRegistrationForm.tsx
@@ -1,5 +1,6 @@
 import { type EventFragment, RegisterToEventDocument } from '@/graphql/Event';
 import { cn } from '@/ui/cn';
+import { buttonCls } from '@/ui/style';
 import { NumberFieldElement } from '@/ui/fields/number';
 import { TextAreaElement } from '@/ui/fields/textarea';
 import { FormError, useFormResult } from '@/ui/form';
@@ -121,14 +122,7 @@ export function NewRegistrationForm({ event }: { event: EventFragment; }) {
               key={id}
               data-state={selected ? 'on' : ''}
               onClick={() => setValue(`registrations.${index}.selected`, !selected, { shouldTouch: true })}
-              className={cn(
-                'flex gap-2 items-center appearance-none',
-                'group w-full data-[state=on]:text-white data-[state=on]:bg-accent-9 bg-neutral-1 text-accent-11',
-                'px-2.5 py-2 text-sm first:rounded-t-xl border last:rounded-b-xl',
-                'border-y border-l last:border-r border-accent-7 data-[state=on]:border-accent-10',
-                'disabled:border-neutral-6 disabled:data-[state=on]:border-neutral-10 disabled:data-[state=on]:bg-neutral-9 disabled:text-neutral-11 disabled:data-[state=on]:text-white',
-                'focus:relative focus:outline-none focus-visible:z-30 focus-visible:ring focus-visible:ring-accent-10'
-              )}
+              className={buttonCls({ display: 'listItem', variant: 'none', size: 'none' })}
             >
               <div className="flex gap-2 items-center">
                 {selected ? (

--- a/frontend/ui/style.tsx
+++ b/frontend/ui/style.tsx
@@ -1,24 +1,36 @@
 import { tv } from 'tailwind-variants';
 
 export const buttonCls = tv({
-  base: 'relative appearance-none',
+  base: 'relative appearance-none focus:outline-none disabled:cursor-not-allowed transition-colors',
   variants: {
     display: {
       none: ' ',
       button: 'inline-flex gap-1 shadow-md uppercase font-medium justify-center items-center',
-      listItem: 'flex flex-col gap-1 shadow-sm font-medium items-start mb-0.5',
+      iconOnly: 'inline-flex items-center justify-center',
+      listItem: [
+        'group w-full text-left flex items-center gap-2',
+        'px-2.5 py-2 text-sm first:rounded-t-xl border last:rounded-b-xl',
+        'bg-neutral-1 text-accent-11 border-y border-l last:border-r border-accent-7',
+        'data-[state=on]:text-white data-[state=on]:bg-accent-9 data-[state=on]:border-accent-10',
+        'disabled:text-neutral-11 disabled:border-neutral-6',
+        'disabled:data-[state=on]:text-white disabled:data-[state=on]:bg-neutral-9 disabled:data-[state=on]:border-neutral-10',
+        'focus-visible:z-30 focus-visible:ring focus-visible:ring-accent-10',
+      ].join(' '),
     },
     variant: {
       none: ' ',
       primary: 'bg-accent-9 hover:bg-accent-10 active:bg-accent-10 text-accent-0 disabled:bg-neutral-3 disabled:text-neutral-11',
       outline: 'bg-accent-2 hover:bg-accent-3 active:bg-accent-5 text-accent-12 border border-accent-6 hover:border-accent-7',
       outlineDark: 'bg-neutral-12 text-neutral-0',
+      subtle: 'bg-transparent text-accent-9 hover:text-accent-10 disabled:text-accent-7 disabled:hover:text-accent-7',
     },
     size: {
+      none: 'p-0 [&_svg]:w-5 [&_svg]:h-5',
       xs: 'px-1.5 py-1 text-xs rounded-xl tracking-tight [&_svg]:w-3 [&_svg]:h-3',
       sm: 'px-2 py-1.5 text-xs rounded-xl tracking-tight [&_svg]:w-3 [&_svg]:h-3',
       md: 'px-3 py-2 text-sm rounded-xl [&_svg]:w-4 [&_svg]:h-4',
       lg: 'px-6 py-3 text-base rounded-xl [&_svg]:w-5 [&_svg]:h-5',
+      icon: 'p-0 leading-none [&_svg]:w-5 [&_svg]:h-5',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary
- expand the shared `buttonCls` helper with icon-only display, subtle styling, and no-padding size options
- replace bespoke button class strings in the registration forms and numeric field with the updated helper to keep behavior consistent

## Testing
- `yarn workspace rozpisovnik-web lint` *(fails: eslint-plugin-unicorn is published as ESM and cannot be required by next lint in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db037466ac8322a4f0c4f986befbd4