### PR TITLE
Refactor tenant navigation configuration

### DIFF
--- a/frontend/calendar/TimeGridEvent.tsx
+++ b/frontend/calendar/TimeGridEvent.tsx
@@ -19,7 +19,7 @@ function formatTrainerLabel(name: string, useInitials: boolean): string {
   }
 
   const sanitized = name
-    .replace(/\b(Mgr\.|Ing\.|Bc\.)\s*/g, '')
+    .replaceAll(/\b(Mgr\.|Ing\.|Bc\.)\s*/g, '')
     .normalize('NFKD')
     .replaceAll(/[^A-Z]/g, '');
 

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -35,10 +35,12 @@ export function Header({ isOpen, setIsOpen, showTopMenu }: Props) {
     setIsMounted(true);
   }, []);
 
+  const renderTopMenu = showTopMenu && topMenu.length > 0;
+
   return (
     <div className="sticky z-20 top-0 inset-x-0 text-white bg-[#292524] shadow-lg">
       <div className="lg:container lg:max-w-6xl relative">
-        {showTopMenu && (
+        {renderTopMenu && (
           <div className="relative hidden lg:flex items-stretch justify-between min-h-[48px] md:min-h-[64px]">
             <DesktopLogo />
             {topMenu.map((x) => (

--- a/frontend/components/layout/Layout.tsx
+++ b/frontend/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import { tenantConfig } from '@/tenant/config.js';
+import { topMenu } from '@/lib/use-menu';
 import { getTenantUi } from '@/tenant/catalog';
 import { ErrorPage } from '@/ui/ErrorPage';
 import { LoginForm } from '@/ui/forms/LoginForm';
@@ -41,9 +42,9 @@ export const Layout = React.memo(function Layout({
   const auth = useAuth();
   const authLoading = useAuthLoading();
 
-  showTopMenu = showTopMenu && tenantConfig.enableHome;
+  showTopMenu = showTopMenu && tenantConfig.enableHome && topMenu.length > 0;
   if (hideTopMenuIfLoggedIn) {
-    showTopMenu = !auth.user;
+    showTopMenu = showTopMenu && !auth.user;
   }
 
   const missingPermission =

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -23,6 +23,12 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
   const router = useRouter();
   const auth = useAuth();
   const setAuth = useSetAtom(authAtom);
+  const hasPublicNavigation = topMenu.length > 0;
+  const canAccessLink = React.useCallback(
+    (link: MenuLink) =>
+      (!link.requireTrainer || auth.isTrainerOrAdmin) && (!link.requireAdmin || auth.isAdmin),
+    [auth.isAdmin, auth.isTrainerOrAdmin],
+  );
 
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
@@ -81,13 +87,22 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
         <div className="space-y-1 pt-3 mr-1">
           {(auth.user && isMounted) ? (
             <>
-              {memberMenu.map((x) => <SidebarSection key={x.title} item={x.type === 'link' ? x : {
-                ...x,
-                children: x.children.filter(item => (
-                  (!item.requireTrainer || auth.isTrainerOrAdmin) &&
-                  (!item.requireAdmin || auth.isAdmin))
-                )
-              }} />)}
+              {memberMenu.map((x) => {
+                if (x.type === 'link') {
+                  return canAccessLink(x) ? (
+                    <SidebarSection key={x.title} item={x} />
+                  ) : null;
+                }
+
+                const filteredChildren = x.children.filter(canAccessLink);
+                if (filteredChildren.length === 0) {
+                  return null;
+                }
+
+                return (
+                  <SidebarSection key={x.title} item={{ ...x, children: filteredChildren }} />
+                );
+              })}
 
               <Link
                 onClick={signOut}
@@ -106,7 +121,7 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
             <SidebarLink item={{ type: 'link', title: 'Přihlásit se', href: '/login' }} />
           )}
 
-          {tenantConfig.enableHome && (
+          {tenantConfig.enableHome && hasPublicNavigation && (
             showTopMenu ? (
               topMenu.map((x) => <SidebarSection key={x.title} item={x} />)
             ) : (

--- a/frontend/lib/use-menu.ts
+++ b/frontend/lib/use-menu.ts
@@ -1,6 +1,11 @@
 import { tenantConfig } from '@/tenant/config';
-import type { LinkProps } from 'next/link'
-type Route = LinkProps['href'];
+import type {
+  Config,
+  NavigationItem,
+  NavigationLink,
+  NavigationMenu,
+  Route,
+} from '@/tenant/types';
 
 export type MenuLink = {
   type: 'link';
@@ -23,88 +28,136 @@ export function getHrefs(x: MenuStructItem): Route[] {
   return x.type === 'link' ? [x.href] : x.children.flatMap((x) => getHrefs(x));
 }
 
-export const topMenu: MenuStructItem[] = [
-  { type: 'link', title: 'Domů', href: '/' },
-  {
-    type: 'menu',
-    title: 'Klub',
-    children: [
-      { type: 'link', title: 'O nás', href: '/o-nas' },
-      { type: 'link', title: 'Kde trénujeme', href: '/kde-trenujeme' },
-      { type: 'link', title: 'Tréninkové programy', href: '/treninkove-programy' },
-      { type: 'link', title: 'Trenéři', href: '/treneri' },
-      { type: 'link', title: 'Výhody členství', href: '/vyhody-clenstvi' },
-      { type: 'link', title: 'Galerie mistrů', href: '/galerie-mistru' },
-    ],
-  },
-  {
-    type: 'menu',
-    title: 'Nabízíme',
-    children: [
-      { type: 'link', title: 'Přípravka tanečního sportu', href: 'https://nabor.tkolymp.cz' as any },
-      { type: 'link', title: 'Vystoupení na akcích', href: '/vystoupeni' },
-      { type: 'link', title: 'Školní taneční kroužky', href: '/skolni-krouzky' },
-    ],
-  },
-  { type: 'link', title: 'Aktuality', href: '/clanky' },
-  { type: 'link', title: 'Galerie', href: '/galerie' },
-  { type: 'link', title: 'Akce', href: '/akce' },
-  { type: 'link', title: 'Kontakt', href: '/kontakt' },
-];
+function toMenuLink(link: NavigationLink, config: Config): MenuLink | null {
+  if (link.recruitmentLink && config.enableRecruitmentLink === false) {
+    return null;
+  }
+  return {
+    type: 'link',
+    title: link.title,
+    href: link.href,
+    requireTrainer: link.requireTrainer,
+    requireAdmin: link.requireAdmin,
+    className: link.className,
+  } satisfies MenuLink;
+}
 
-export const memberMenu: MenuStructItem[] = [
-  { type: 'link', title: 'Nástěnka', href: {
-    pathname: '/dashboard',
-    query: { tab: 'myAnnouncements' },
-  } },
-  ...(tenantConfig.enableArticles ? [
-    { type: 'link', title: 'Stálá nástěnka', className: 'lg:hidden', href: {
-      pathname: '/dashboard',
-      query: { tab: 'stickyAnnouncements' },
-    } },
-  ] as MenuStructItem[] : []),
-  { type: 'link', title: 'Profil', href: '/profil' },
-  {
-    type: 'menu',
+function isMenuLink(link: MenuLink | null): link is MenuLink {
+  return link !== null;
+}
+
+function toMenuItem(item: NavigationItem, config: Config): MenuStructItem | null {
+  if ('children' in item) {
+    const children = item.children
+      .map((child) => toMenuLink(child, config))
+      .filter(isMenuLink);
+    if (children.length === 0) {
+      return null;
+    }
+    return { type: 'menu', title: item.title, children } satisfies MenuStructItem;
+  }
+  return toMenuLink(item, config);
+}
+
+function isMenuStructItem(item: MenuStructItem | null): item is MenuStructItem {
+  return item !== null;
+}
+
+function buildMenu(items: NavigationItem[] | undefined, config: Config): MenuStructItem[] {
+  return (items ?? [])
+    .map((item) => toMenuItem(item, config))
+    .filter(isMenuStructItem);
+}
+
+function getDefaultMemberNavigation(config: Config): NavigationItem[] {
+  const navigation: NavigationItem[] = [
+    {
+      title: 'Nástěnka',
+      href: {
+        pathname: '/dashboard',
+        query: { tab: 'myAnnouncements' },
+      },
+    },
+  ];
+
+  if (config.enableArticles) {
+    navigation.push({
+      title: 'Stálá nástěnka',
+      className: 'lg:hidden',
+      href: {
+        pathname: '/dashboard',
+        query: { tab: 'stickyAnnouncements' },
+      },
+    });
+  }
+
+  navigation.push({ title: 'Profil', href: '/profil' });
+
+  const trainingMenu: NavigationMenu = {
     title: 'Tréninky',
     children: [
-      { type: 'link', title: 'Moje tréninky', href: {
-        pathname: '/dashboard',
-        query: { tab: 'myLessons' },
-      } },
-      { type: 'link', title: 'Kalendář', href: '/rozpis' },
-      { type: 'link', title: 'Seznam akcí', href: '/akce' },
+      {
+        title: 'Moje tréninky',
+        href: {
+          pathname: '/dashboard',
+          query: { tab: 'myLessons' },
+        },
+      },
+      { title: 'Kalendář', href: '/rozpis' },
+      { title: 'Seznam akcí', href: '/akce' },
     ],
-  },
-  {
-    type: 'menu',
+  };
+
+  const clubMenu: NavigationMenu = {
     title: 'Taneční klub',
     children: [
-      { type: 'link', title: 'Klub', href: '/tanecni-klub' },
-      { type: 'link', title: 'Tréninkové skupiny', href: '/treninkove-skupiny' },
-      { type: 'link', title: 'Páry', href: '/pary' },
-      { type: 'link', title: 'Členové', href: '/clenove' },
-      { type: 'link', title: 'Žebříček', href: '/zebricek' },
-      ...(tenantConfig.enableArticles ? [
-        { type: 'link', title: 'Dokumenty', href: '/dokumenty' } as MenuLink,
-      ] : []),
+      { title: 'Klub', href: '/tanecni-klub' },
+      { title: 'Tréninkové skupiny', href: '/treninkove-skupiny' },
+      { title: 'Páry', href: '/pary' },
+      { title: 'Členové', href: '/clenove' },
+      { title: 'Žebříček', href: '/zebricek' },
     ],
-  },
-  {
-    type: 'menu',
+  };
+
+  if (config.enableArticles) {
+    clubMenu.children.push({ title: 'Dokumenty', href: '/dokumenty' });
+  }
+
+  const adminMenu: NavigationMenu = {
     title: 'Správa',
     children: [
-      { type: 'link', title: 'Pozvánky', href: '/pozvanky', requireAdmin: true },
-      { type: 'link', title: 'Nástěnka', href: '/nastenka', requireTrainer: true },
-      { type: 'link', title: 'Platby', href: '/platby', requireAdmin: true },
-      ...(tenantConfig.enableArticles ? [
-        { type: 'link', title: 'Články', href: '/aktuality', requireTrainer: true },
-        { type: 'link', title: 'Vyplněné formuláře', href: '/crm', requireAdmin: true },
-        { type: 'link', title: 'Upload (WIP)', href: '/upload', requireAdmin: true },
-      ] as MenuLink[] : []),
-      ...(tenantConfig.enableStarletImport ? [
-        { type: 'link', title: 'Import z evidence', href: '/starlet-import', requireAdmin: true },
-      ] as MenuLink[] : []),
+      { title: 'Pozvánky', href: '/pozvanky', requireAdmin: true },
+      { title: 'Nástěnka', href: '/nastenka', requireTrainer: true },
+      { title: 'Platby', href: '/platby', requireAdmin: true },
     ],
-  },
-];
+  };
+
+  if (config.enableArticles) {
+    adminMenu.children.push(
+      { title: 'Články', href: '/aktuality', requireTrainer: true },
+      { title: 'Vyplněné formuláře', href: '/crm', requireAdmin: true },
+      { title: 'Upload (WIP)', href: '/upload', requireAdmin: true },
+    );
+  }
+
+  if (config.enableStarletImport) {
+    adminMenu.children.push({
+      title: 'Import z evidence',
+      href: '/starlet-import',
+      requireAdmin: true,
+    });
+  }
+
+  navigation.push(trainingMenu, clubMenu, adminMenu);
+
+  return navigation;
+}
+
+const defaultMemberNavigation = getDefaultMemberNavigation(tenantConfig);
+
+export const topMenu: MenuStructItem[] = buildMenu(tenantConfig.publicNavigation, tenantConfig);
+
+export const memberMenu: MenuStructItem[] = buildMenu(
+  tenantConfig.memberNavigation ?? defaultMemberNavigation,
+  tenantConfig,
+);

--- a/frontend/tenant/kometa/config.js
+++ b/frontend/tenant/kometa/config.js
@@ -7,10 +7,32 @@ module.exports = {
   favicon: '',
   enableHome: false,
   enableArticles: false,
+  enableRecruitmentLink: false,
   enableStarletImport: false,
   useTrainerInitials: false,
   lockEventsByDefault: false,
   themePrimary: '#be9f69',
   themeAccent: 'gold',
   themeNeutral: 'mauve',
+  publicNavigation: [
+    { title: 'Domů', href: '/' },
+    {
+      title: 'Klub',
+      children: [
+        { title: 'O nás', href: '/o-nas' },
+        { title: 'Kde trénujeme', href: '/kde-trenujeme' },
+        { title: 'Trenéři', href: '/treneri' },
+      ],
+    },
+    {
+      title: 'Nabízíme',
+      children: [
+        { title: 'Vystoupení na akcích', href: '/vystoupeni' },
+        { title: 'Školní taneční kroužky', href: '/skolni-krouzky' },
+      ],
+    },
+    { title: 'Galerie', href: '/galerie' },
+    { title: 'Akce', href: '/akce' },
+    { title: 'Kontakt', href: '/kontakt' },
+  ],
 };

--- a/frontend/tenant/olymp/config.js
+++ b/frontend/tenant/olymp/config.js
@@ -7,6 +7,7 @@ module.exports = {
   favicon: '',
   enableHome: true,
   enableArticles: true,
+  enableRecruitmentLink: true,
   enableStarletImport: false,
   useTrainerInitials: false,
   lockEventsByDefault: false,
@@ -14,4 +15,34 @@ module.exports = {
   themeAccent: 'red',
   themeNeutral: 'gray',
   facebookPixelId: '704526480597551',
+  publicNavigation: [
+    { title: 'Domů', href: '/' },
+    {
+      title: 'Klub',
+      children: [
+        { title: 'O nás', href: '/o-nas' },
+        { title: 'Kde trénujeme', href: '/kde-trenujeme' },
+        { title: 'Tréninkové programy', href: '/treninkove-programy' },
+        { title: 'Trenéři', href: '/treneri' },
+        { title: 'Výhody členství', href: '/vyhody-clenstvi' },
+        { title: 'Galerie mistrů', href: '/galerie-mistru' },
+      ],
+    },
+    {
+      title: 'Nabízíme',
+      children: [
+        {
+          title: 'Přípravka tanečního sportu',
+          href: 'https://nabor.tkolymp.cz',
+          recruitmentLink: true,
+        },
+        { title: 'Vystoupení na akcích', href: '/vystoupeni' },
+        { title: 'Školní taneční kroužky', href: '/skolni-krouzky' },
+      ],
+    },
+    { title: 'Aktuality', href: '/clanky' },
+    { title: 'Galerie', href: '/galerie' },
+    { title: 'Akce', href: '/akce' },
+    { title: 'Kontakt', href: '/kontakt' },
+  ],
 };

--- a/frontend/tenant/starlet/config.js
+++ b/frontend/tenant/starlet/config.js
@@ -7,12 +7,37 @@ module.exports = {
   favicon: '',
   enableHome: false,
   enableArticles: false,
+  enableRecruitmentLink: false,
   enableStarletImport: true,
   useTrainerInitials: true,
   lockEventsByDefault: true,
   themePrimary: '#D7A238',
   themeAccent: 'orange',
   themeNeutral: 'olive',
+  publicNavigation: [
+    { title: 'Domů', href: '/' },
+    {
+      title: 'Klub',
+      children: [
+        { title: 'O nás', href: '/o-nas' },
+        { title: 'Kde trénujeme', href: '/kde-trenujeme' },
+        { title: 'Tréninkové programy', href: '/treninkove-programy' },
+        { title: 'Trenéři', href: '/treneri' },
+        { title: 'Výhody členství', href: '/vyhody-clenstvi' },
+        { title: 'Galerie mistrů', href: '/galerie-mistru' },
+      ],
+    },
+    {
+      title: 'Nabízíme',
+      children: [
+        { title: 'Vystoupení na akcích', href: '/vystoupeni' },
+        { title: 'Školní taneční kroužky', href: '/skolni-krouzky' },
+      ],
+    },
+    { title: 'Galerie', href: '/galerie' },
+    { title: 'Akce', href: '/akce' },
+    { title: 'Kontakt', href: '/kontakt' },
+  ],
   accentLight: {
     orange1: 'hsl(45, 67%, 99%)',
     orange2: 'hsl(46, 100%, 96%)',

--- a/frontend/tenant/types.ts
+++ b/frontend/tenant/types.ts
@@ -1,3 +1,23 @@
+import type { LinkProps } from 'next/link';
+
+export type Route = LinkProps['href'];
+
+export type NavigationLink = {
+  title: string;
+  href: Route;
+  requireTrainer?: boolean;
+  requireAdmin?: boolean;
+  className?: string;
+  recruitmentLink?: boolean;
+};
+
+export type NavigationMenu = {
+  title: string;
+  children: NavigationLink[];
+};
+
+export type NavigationItem = NavigationLink | NavigationMenu;
+
 export type Config = {
   shortName: string;
   copyrightLine: string;
@@ -15,4 +35,7 @@ export type Config = {
   accentDark?: Record<string, string>;
   neutralLight?: Record<string, string>;
   neutralDark?: Record<string, string>;
+  publicNavigation: NavigationItem[];
+  memberNavigation?: NavigationItem[];
+  enableRecruitmentLink?: boolean;
 }

--- a/frontend/ui/AuthButton.tsx
+++ b/frontend/ui/AuthButton.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuTrigger,
 } from '@/ui/dropdown';
 import { useAuth } from '@/ui/use-auth';
-import { memberMenu } from '@/lib/use-menu';
+import { memberMenu, type MenuLink } from '@/lib/use-menu';
 import { User as Account } from 'lucide-react';
 import React from 'react';
 import { useSetAtom } from 'jotai';
@@ -19,6 +19,11 @@ import Link from 'next/link';
 export function AuthButton() {
   const auth = useAuth();
   const setAuth = useSetAtom(authAtom);
+  const canAccessLink = React.useCallback(
+    (link: MenuLink) =>
+      (!link.requireTrainer || auth.isTrainerOrAdmin) && (!link.requireAdmin || auth.isAdmin),
+    [auth.isAdmin, auth.isTrainerOrAdmin],
+  );
 
   const [isMounted, setIsMounted] = React.useState(false);
   React.useEffect(() => {
@@ -53,21 +58,34 @@ export function AuthButton() {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">
-        {memberMenu.map((item) =>
-          item.type === 'link' ? (
-            <DropdownMenuLink key={JSON.stringify(item.href)} href={item.href}>
-              {item.title}
-            </DropdownMenuLink>
-          ) : (
+        {memberMenu.map((item) => {
+          if (item.type === 'link') {
+            if (!canAccessLink(item)) {
+              return null;
+            }
+            return (
+              <DropdownMenuLink key={JSON.stringify(item.href)} href={item.href}>
+                {item.title}
+              </DropdownMenuLink>
+            );
+          }
+
+          const visibleChildren = item.children.filter(canAccessLink);
+          if (visibleChildren.length === 0) {
+            return null;
+          }
+
+          return (
             <React.Fragment key={item.title}>
               <DropdownMenuLabel>{item.title}</DropdownMenuLabel>
-              {item.children.filter((item) => (!item.requireTrainer || auth.isTrainerOrAdmin) && (!item.requireAdmin || auth.isAdmin)).map((item) => (
-                <DropdownMenuLink key={JSON.stringify(item.href)} href={item.href}>
-                  {item.title}
+              {visibleChildren.map((child) => (
+                <DropdownMenuLink key={JSON.stringify(child.href)} href={child.href}>
+                  {child.title}
                 </DropdownMenuLink>
               ))}
             </React.Fragment>
-          ))}
+          );
+        })}
         <DropdownMenuButton onClick={signOut}>Odhlásit se</DropdownMenuButton>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- extend tenant configuration with typed public/member navigation descriptors and a recruitment link toggle
- populate tenant-specific navigation menus and derive frontend menus from the shared config
- update layout/auth components to respect role guards, hide empty menus, and adjust lint violations

## Testing
- yarn workspace rozpisovnik-web lint

------
https://chatgpt.com/codex/tasks/task_e_68e900ea7a288322a3635f02346bc8f2