### PR TITLE
Align header and shell surfaces with palette tokens

### DIFF
--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -11,7 +11,7 @@ const SocialIcons = dynamic(() => getTenantUi('SocialIcons'), { ssr: false });
 const Sponsors = dynamic(() => getTenantUi('Sponsors'), { ssr: false });
 
 function Footer() {
-  return <div className="col-full-width content bg-[#292524] text-white py-12">
+  return <div className="col-full-width content bg-neutral-1 text-neutral-12 py-12">
     <div className="col-feature grid grid-cols-2 gap-2">
       <h2 className="col-span-2 text-3xl font-bold">Kontakt</h2>
       <div className="col-span-2 md:col-span-1">

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -36,7 +36,7 @@ export function Header({ isOpen, setIsOpen, showTopMenu }: Props) {
   }, []);
 
   return (
-    <div className="sticky z-20 top-0 inset-x-0 text-white bg-[#292524] shadow-lg">
+    <div className="sticky z-20 top-0 inset-x-0 text-neutral-12 bg-neutral-1 shadow-lg">
       <div className="lg:container lg:max-w-6xl relative">
         {showTopMenu && (
           <div className="relative hidden lg:flex items-stretch justify-between min-h-[48px] md:min-h-[64px]">
@@ -85,10 +85,11 @@ function DesktopMenuItem({ item: x }: { item: MenuStructItem }) {
   const classes = cn(
     'flex gap-1 rounded-none transition-colors',
     'uppercase text-sm font-bold justify-center items-center',
-    'hover:text-white hover:border-b-[3px] border-white data-[state=open]:border-b-[3px]',
+    'border-b-[3px] border-transparent hover:border-accent-8 data-[state=open]:border-accent-9',
+    'hover:text-neutral-12',
     inPath
-      ? 'text-white drop-shadow-xl border-b-[3px] tracking-wide -mb-px'
-      : 'text-[#f3f3f3] drop-shadow',
+      ? 'text-neutral-12 drop-shadow-xl border-accent-9 tracking-wide -mb-px'
+      : 'text-neutral-11 drop-shadow',
   );
   if (x.type === 'link') {
     return (

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -57,7 +57,7 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
       <div
         onClick={() => setIsOpen(false)}
         className={cn(
-          "fixed inset-0 z-20 bg-black/10 transition duration-200 ease-in-out",
+          'fixed inset-0 z-20 bg-neutral-12/10 transition duration-200 ease-in-out',
           isOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
         )}
       />
@@ -71,7 +71,7 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
           showTopMenu ? 'lg:hidden' : '',
           'w-3/4 sm:w-1/2 md:w-1/3 lg:w-56 xl:w-64 2xl:w-72 3xl:w-80',
           'z-50 lg:z-auto flex-none pb-10 transition duration-200 ease-in-out sm:pb-0',
-          'bg-accent-1 lg:bg-primary lg:text-white',
+          'bg-accent-1 text-neutral-12 lg:bg-primary lg:text-accent-10',
           'overflow-y-auto scrollbar max-h-screen min-h-screen'
         )}
       >
@@ -107,7 +107,7 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
                 href={tenantConfig.enableHome ? '/' : '/dashboard'}
                 className={cn(
                   'rounded-2xl px-3 py-1.5',
-                  'flex items-center grow mx-2 hover:bg-accent-10 hover:text-white',
+                  'flex items-center grow mx-2 transition-colors hover:bg-accent-5 hover:text-accent-12',
                   'tracking-wider text-sm',
                 )}
               >
@@ -127,7 +127,7 @@ export function Sidebar({ isOpen, setIsOpen, showTopMenu }: SidebarProps) {
             )
           )}
 
-          <div className="mt-4 text-xs text-neutral-11 lg:text-white p-4 grid gap-2">
+          <div className="mt-4 text-xs text-neutral-11 lg:text-accent-10 p-4 grid gap-2">
             <div>{tenantConfig.copyrightLine}</div>
             <div>Verze: {buildId?.slice(0, 7)}</div>
             <div>
@@ -162,9 +162,11 @@ function SidebarLink({ item, onClick }: SidebarLinkProps) {
       onClick={onClick}
       className={cn(
         'rounded-2xl px-3 py-1.5',
-        'flex items-center grow mx-2 hover:bg-accent-10 hover:text-white',
+        'flex items-center grow mx-2 transition-colors hover:bg-accent-5 hover:text-accent-12',
         'tracking-wider text-sm',
-        inPath ? 'underline font-bold bg-neutral-11 text-white lg:bg-accent-9' : '',
+        inPath
+          ? 'underline font-bold bg-neutral-4 text-neutral-12 lg:bg-accent-6 lg:text-accent-12'
+          : '',
         item.className,
       )}
     >


### PR DESCRIPTION
## Summary
- replace header background and menu highlight colors with neutral/accent palette utilities
- move footer and sidebar surfaces to palette-backed neutrals with updated hover/active states for contrast
- refresh sidebar overlay/text treatments so responsive views keep tenant branding legible

## Testing
- env CI=1 yarn workspace rozpisovnik-web build *(fails: existing error loading /404 during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68ee3ee5f4d0832290ed5edd837338f3