### PR TITLE
Refine person payments table

### DIFF
--- a/frontend/ui/DataTable.tsx
+++ b/frontend/ui/DataTable.tsx
@@ -86,6 +86,10 @@ export type DataTableProps<TData, TValue> = {
   /** navigation */
   onRowClick?: (row: Row<TData>) => void;
   renderExpanded?: (row: TData) => React.ReactNode;
+
+  /** feature toggles */
+  enableSelection?: boolean;
+  enablePagination?: boolean;
 }
 
 export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
@@ -111,6 +115,9 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
     selectedActions,
     onRowClick,
     renderExpanded,
+
+    enableSelection = true,
+    enablePagination = true,
   } = props
 
   // internal fallbacks
@@ -121,16 +128,16 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   const [iSelection, iSetSelection] = React.useState<RowSelectionState>(ext?.rowSelection ?? {})
   const [iExpanded, iSetExpanded] = React.useState<ExpandedState>(ext?.expanded ?? {})
   const [iPagination, iSetPagination] = React.useState<PaginationState>(
-    ext?.pagination ?? { pageIndex: 0, pageSize: 20 }
+    ext?.pagination ?? { pageIndex: 0, pageSize: 50 }
   )
 
   const sorting = ext?.sorting ?? iSorting
   const columnFilters = ext?.columnFilters ?? iColFilters
   const globalFilter = ext?.globalFilter ?? iGlobal
   const columnVisibility = ext?.columnVisibility ?? iColVis
-  const rowSelection = ext?.rowSelection ?? iSelection
+  const rowSelection = (enableSelection ? ext?.rowSelection : undefined) ?? iSelection
   const expanded = ext?.expanded ?? iExpanded
-  const pagination = ext?.pagination ?? iPagination
+  const pagination = enablePagination ? ext?.pagination ?? iPagination : undefined
 
   const setSorting = extSetSorting ?? iSetSorting
   const setColFilters = extSetColFilters ?? iSetColFilters
@@ -143,8 +150,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
     columns: [
-      // selection column
-      {
+      enableSelection && {
         id: "__select",
         size: 36,
         header: ({ table }) => (
@@ -170,7 +176,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
         cell: ({ row }) => (
           <button
             onClick={row.getToggleExpandedHandler()}
-            className="size-7 rounded-md border border-neutral-6 bg-neutral-2 text-neutral-12 transition hover:border-neutral-7 hover:bg-neutral-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
+            className="size-7 rounded-md border border-neutral-6 bg-neutral-1 text-neutral-12 transition hover:border-neutral-7 hover:bg-neutral-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
             aria-label={row.getIsExpanded() ? "Collapse" : "Expand"}
           >
             {row.getIsExpanded() ? "−" : "+"}
@@ -182,32 +188,32 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       },
       // user columns
       ...columns,
-    ] as ColumnDef<TData, TValue>[],
+    ].filter(Boolean) as ColumnDef<TData, TValue>[],
     state: {
       sorting,
       columnFilters,
       globalFilter,
       columnVisibility,
-      rowSelection,
+      ...(enableSelection ? { rowSelection } : {}),
       expanded,
-      pagination,
+      ...(enablePagination && pagination ? { pagination } : {}),
     },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColFilters,
     onGlobalFilterChange: setGlobal,
     onColumnVisibilityChange: setColVis,
-    onRowSelectionChange: setSelection,
+    onRowSelectionChange: enableSelection ? setSelection : undefined,
     onExpandedChange: setExpanded,
-    onPaginationChange: setPagination,
+    onPaginationChange: enablePagination ? setPagination : undefined,
 
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
+    getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
     globalFilterFn: fuzzyFilter,
     filterFns: { fuzzy: fuzzyFilter },
-    enableRowSelection: true,
+    enableRowSelection: enableSelection,
     getRowCanExpand: React.useMemo(() => renderExpanded ? () => true : () => false, [renderExpanded]),
     debugTable: false,
   })
@@ -229,12 +235,12 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
     ? rowVirtualizer.getTotalSize() - virtualItems.at(-1)!.end
     : 0
 
-  const selected = table.getFilteredSelectedRowModel().rows
+  const selected = enableSelection ? table.getFilteredSelectedRowModel().rows : []
 
   return (
-    <div className="space-y-4 rounded-xl border border-neutral-6 bg-neutral-2 p-4 shadow-sm">
+    <div className="space-y-4 rounded-xl border border-neutral-6 bg-neutral-1/80 p-4 shadow-sm">
       {/* Toolbar / Selected actions */}
-      {selected.length > 0 ? (
+      {enableSelection && selected.length > 0 ? (
         selectedActions ? (
           <div>{selectedActions({ selected: selected.map((r) => r.original), table })}</div>
         ) : (
@@ -266,7 +272,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
         className="max-h-[60vh] overflow-auto rounded-lg border border-neutral-6 bg-neutral-1 shadow-inner [scrollbar-gutter:stable]"
       >
         <table className="min-w-full border-collapse text-sm">
-          <thead className="sticky top-0 z-10 bg-neutral-2/90 backdrop-blur">
+          <thead className="sticky top-0 z-10 bg-neutral-2/80 backdrop-blur">
             {table.getHeaderGroups().map((hg) => (
               <tr key={hg.id} className="text-left">
                 {hg.headers.map((h) => (
@@ -305,8 +311,8 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
               return (
                 <React.Fragment key={row.id}>
                   <tr
-                    data-selected={row.getIsSelected() ? "" : undefined}
-                    className="cursor-default border-b border-neutral-6 transition data-[selected]:bg-[color-mix(in_oklab,var(--accent-9)_10%,transparent)] hover:bg-neutral-2"
+                    data-selected={enableSelection && row.getIsSelected() ? "" : undefined}
+                    className="cursor-default border-b border-neutral-6 transition data-[selected]:bg-accent-3 hover:bg-neutral-2/60"
                     style={{ height: v.size }}
                     onClick={() => onRowClick?.(row)}
                   >
@@ -342,27 +348,29 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       </div>
 
       {/* Footer */}
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-6 bg-neutral-1 px-3 py-2 text-sm text-neutral-11">
-        <div className="font-medium text-neutral-12">
-          {selected.length} / {table.getFilteredRowModel().rows.length} selected
+      {enablePagination && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-6 bg-neutral-1 px-3 py-2 text-sm text-neutral-11">
+          <div className="font-medium text-neutral-12">
+            {selected.length} / {table.getFilteredRowModel().rows.length} selected
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              className="rounded-lg border border-neutral-6 bg-neutral-2 px-3 py-1.5 text-sm text-neutral-12 transition enabled:hover:border-neutral-7 enabled:hover:bg-neutral-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
+            >
+              Prev
+            </button>
+            <button
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              className="rounded-lg border border-neutral-6 bg-neutral-2 px-3 py-1.5 text-sm text-neutral-12 transition enabled:hover:border-neutral-7 enabled:hover:bg-neutral-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
+            >
+              Next
+            </button>
+          </div>
         </div>
-        <div className="flex gap-2">
-          <button
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            className="rounded-lg border border-neutral-6 bg-neutral-2 px-3 py-1.5 text-sm text-neutral-12 transition enabled:hover:border-neutral-7 enabled:hover:bg-neutral-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
-          >
-            Prev
-          </button>
-          <button
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            className="rounded-lg border border-neutral-6 bg-neutral-2 px-3 py-1.5 text-sm text-neutral-12 transition enabled:hover:border-neutral-7 enabled:hover:bg-neutral-3 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
-          >
-            Next
-          </button>
-        </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/frontend/ui/DataTable.tsx
+++ b/frontend/ui/DataTable.tsx
@@ -18,6 +18,8 @@ import {
   type PaginationState,
   type Table as TableType,
   type Row,
+  type HeaderContext,
+  type CellContext,
   OnChangeFn,
 } from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -153,14 +155,14 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       enableSelection && {
         id: "__select",
         size: 36,
-        header: ({ table }) => (
+        header: ({ table }: HeaderContext<TData, unknown>) => (
           <RadixCheckbox
             checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
             onCheckedChange={(v) => table.toggleAllPageRowsSelected(!!v)}
             ariaLabel="Select all rows"
           />
         ),
-        cell: ({ row }) => (
+        cell: ({ row }: CellContext<TData, unknown>) => (
           <RadixCheckbox
             checked={row.getIsSelected()}
             onCheckedChange={(v) => row.toggleSelected(!!v)}
@@ -173,7 +175,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       renderExpanded && {
         id: "__expand",
         header: () => null,
-        cell: ({ row }) => (
+        cell: ({ row }: CellContext<TData, unknown>) => (
           <button
             onClick={row.getToggleExpandedHandler()}
             className="size-7 rounded-md border border-neutral-6 bg-neutral-1 text-neutral-12 transition hover:border-neutral-7 hover:bg-neutral-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8"
@@ -246,14 +248,6 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
         ) : (
           <div className="flex items-center gap-3 rounded-lg border border-neutral-6 bg-neutral-1 px-3 py-2 text-sm text-neutral-12 shadow-sm">
             <span className="font-medium text-neutral-11">{selected.length} selected</span>
-            <div className="ml-auto flex gap-2">
-              <button className="rounded-lg border border-neutral-6 bg-neutral-2 px-3 py-1.5 text-sm text-neutral-12 transition hover:border-neutral-7 hover:bg-neutral-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-8">
-                Export
-              </button>
-              <button className="rounded-lg bg-[var(--tomato-9)] px-3 py-1.5 text-sm font-medium text-white transition hover:bg-[var(--tomato-10)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--tomato-9)]">
-                Delete
-              </button>
-            </div>
           </div>
         )
       ) : toolbar ? (

--- a/frontend/ui/PersonPaymentsView.tsx
+++ b/frontend/ui/PersonPaymentsView.tsx
@@ -1,7 +1,5 @@
 import { PersonPaymentsDocument, type PersonPaymentsQuery } from "@/graphql/Person";
 import React from "react";
-import { ColumnDef } from "@tanstack/react-table";
-import { DataTable } from "@/ui/DataTable";
 import { describePosting, fullDateFormatter, moneyFormatter, numericDateFormatter } from "@/ui/format";
 import { useMutation, useQuery } from "urql";
 import { QRPayment } from "@/ui/QRPayment";
@@ -15,6 +13,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuBut
 import { DeleteTransactionDocument } from "@/graphql/Payment";
 import { PaymentMenu } from "./EventView";
 import { keyIsNonNull } from "./truthyFilter";
+import { ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/ui/DataTable";
 
 export function PersonPaymentsView({ id }: { id: string }) {
   const auth = useAuth();
@@ -26,65 +26,49 @@ export function PersonPaymentsView({ id }: { id: string }) {
     return null;
   }
 
-  const accounts = (person.accountsList ?? []).filter(Boolean) as Account[];
-
   return (
-    <div className="space-y-8">
-      {person.unpaidPayments.length > 0 && (
-        <div className="prose prose-accent space-y-4">
-          <h3>K zaplacení</h3>
-          {person.unpaidPayments.map((x) => (
-            <div key={x.id} className="space-y-3 rounded-xl border border-neutral-6 bg-neutral-1/80 p-4">
-              {x.payment?.cohortSubscription && (
-                <h4>Členské příspěvky {x.payment.cohortSubscription.cohort?.name}</h4>
-              )}
-              <dl className="not-prose grid grid-cols-1 gap-1 sm:grid-cols-2">
-                <div>
-                  <dt>Částka</dt>
-                  <dd>{moneyFormatter.format(x.price)}</dd>
-                </div>
-                <div>
-                  <dt>Účet</dt>
-                  <dd>1806875329/0800</dd>
-                </div>
-                <div>
-                  <dt>Variabilní symbol</dt>
-                  <dd>{x.payment?.variableSymbol}</dd>
-                </div>
-                <div>
-                  <dt>Specifický symbol</dt>
-                  <dd>{x.payment?.specificSymbol}</dd>
-                </div>
-                <div className="sm:col-span-2">
-                  <dt>Zpráva</dt>
-                  <dd>
-                    {person.firstName} {person.lastName}, {x.payment?.cohortSubscription?.cohort?.name}
-                  </dd>
-                </div>
-                {x.payment?.dueAt && (
-                  <div>
-                    <dt>Splatnost</dt>
-                    <dd>{fullDateFormatter.format(new Date(x.payment?.dueAt))}</dd>
-                  </div>
-                )}
-              </dl>
+    <div className="prose prose-accent mb-2">
+      {person.unpaidPayments.length > 0 && <h3>K zaplacení</h3>}
+      {person.unpaidPayments.map(x => (
+        <div key={x.id}>
+          {x.payment?.cohortSubscription && (
+            <h4>Členské příspěvky {x.payment.cohortSubscription.cohort?.name}</h4>
+          )}
+          <dl className="not-prose mb-2">
+            <dt>Částka</dt>
+            <dd>
+              {moneyFormatter.format(x.price)}
+            </dd>
+            <dt>Účet</dt>
+            <dd>1806875329/0800</dd>
+            <dt>Variabilní symbol</dt>
+            <dd>{x.payment?.variableSymbol}</dd>
+            <dt>Specifický symbol</dt>
+            <dd>{x.payment?.specificSymbol}</dd>
+            <dt>Zpráva</dt>
+            <dd>{person.firstName} {person.lastName}, {x.payment?.cohortSubscription?.cohort?.name}</dd>
+            {x.payment?.dueAt && (
+              <>
+                <dt>Splatnost</dt>
+                <dd>{fullDateFormatter.format(new Date(x.payment?.dueAt))}</dd>
+              </>
+            )}
+          </dl>
 
-              {tenant?.bankAccount && x.price?.amount && (
-                <div className="w-fit border-4 border-transparent dark:border-white">
-                  <QRPayment
-                    acc={tenant.bankAccount}
-                    am={x.price.amount}
-                    cc={x.price.currency || "CZK"}
-                    ss={x.payment?.specificSymbol}
-                    vs={x.payment?.variableSymbol}
-                    msg={`${person.firstName} ${person.lastName}, ${x.payment?.cohortSubscription?.cohort?.name}`}
-                  />
-                </div>
-              )}
+          {tenant?.bankAccount && x.price?.amount && (
+            <div className="border-4 border-transparent dark:border-white w-fit">
+              <QRPayment
+                acc={tenant.bankAccount}
+                am={x.price.amount}
+                cc={x.price.currency || 'CZK'}
+                ss={x.payment?.specificSymbol}
+                vs={x.payment?.variableSymbol}
+                msg={`${person.firstName} ${person.lastName}, ${x.payment?.cohortSubscription?.cohort?.name}`}
+              />
             </div>
-          ))}
+          )}
         </div>
-      )}
+      ))}
 
       {auth.isAdmin && (
         <div className="flex gap-2">
@@ -96,37 +80,29 @@ export function PersonPaymentsView({ id }: { id: string }) {
           </Dialog>
         </div>
       )}
+      {person.accountsList.length === 0 && <p>Žádné evidované platby</p>}
+      {person.accountsList?.map(account => (
+        <div key={account.id}>
+          <div className="flex flex-wrap justify-between">
+            <div>Stav kreditu: {moneyFormatter.format({ amount: account.balance, currency: account.currency})}</div>
 
-      {accounts.length === 0 ? (
-        <p className="text-sm text-neutral-11">Žádné evidované platby</p>
-      ) : (
-        accounts.map((account) => (
-          <section key={account.id} className="space-y-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="text-sm text-neutral-12">
-                Stav kreditu: {moneyFormatter.format({ amount: account.balance, currency: account.currency ?? "CZK" })}
-              </div>
+            <div className="flex gap-2">
               <button
                 type="button"
                 className={buttonCls()}
-                onClick={() =>
-                  exportPostings(
-                    `${new Date().getFullYear()}-${new Date().getMonth()} ${person?.name}`,
-                    account.postingsList || []
-                  )
-                }
+                onClick={() => exportPostings(`${new Date().getFullYear()}-${new Date().getMonth()} ${person?.name}`, account.postingsList || [])}
               >
                 Export XLSX
               </button>
             </div>
+          </div>
 
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-neutral-11">Minulé</h3>
-              <AccountPaymentsTable account={account} />
-            </div>
-          </section>
-        ))
-      )}
+          <div>
+            <h3>Minulé</h3>
+            <AccountPaymentsTable account={account} />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -148,84 +124,62 @@ function TransactionMenu({ id, children }: { id: string; children: React.ReactNo
 
 type Account = NonNullable<NonNullable<PersonPaymentsQuery["person"]>["accountsList"]>[number];
 type Posting = NonNullable<Account["postingsList"]>[number];
-type PostingRow = {
-  id: string;
-  posting: Posting;
-  transaction: NonNullable<Posting["transaction"]>;
-  payment: NonNullable<Posting["transaction"]>["payment"] | null;
-};
+type PostingRow = Posting & { transaction: NonNullable<Posting["transaction"]> };
 
 function AccountPaymentsTable({ account }: { account: Account }) {
-  const rows = React.useMemo<PostingRow[]>(() => {
-    const list = (account.postingsList ?? []).filter(Boolean) as Posting[];
-    const filtered = list.filter(keyIsNonNull("transaction"));
-    return filtered
-      .sort((a, b) => b.transaction.effectiveDate.localeCompare(a.transaction.effectiveDate))
-      .map((posting) => {
-        const transaction = posting.transaction;
-        return {
-          id: posting.id,
-          posting,
-          transaction,
-          payment: transaction.payment,
-        } satisfies PostingRow;
-      });
-  }, [account.postingsList]);
-
   const currency = account.currency ?? "CZK";
+  const rows = (account.postingsList ?? [])
+    .filter(keyIsNonNull("transaction")) as PostingRow[];
+  rows.sort((a, b) => b.transaction.effectiveDate.localeCompare(a.transaction.effectiveDate));
 
-  const columns = React.useMemo<ColumnDef<PostingRow, unknown>[]>(
-    () => [
-      {
-        id: "actions",
-        header: "",
-        size: 36,
-        enableSorting: false,
-        enableHiding: false,
-        cell: ({ row }) => {
-          const { payment, transaction } = row.original;
-          const trigger = <DropdownMenuTrigger.RowDots className="text-neutral-10 hover:text-neutral-12" />;
-          return payment ? (
-            <PaymentMenu id={payment.id}>{trigger}</PaymentMenu>
-          ) : (
-            <TransactionMenu id={transaction.id}>{trigger}</TransactionMenu>
-          );
-        },
+  const columns: ColumnDef<PostingRow, unknown>[] = [
+    {
+      id: "actions",
+      header: "",
+      size: 36,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const { transaction } = row.original;
+        const trigger = <DropdownMenuTrigger.RowDots className="text-neutral-10 hover:text-neutral-12" />;
+        return transaction.payment ? (
+          <PaymentMenu id={transaction.payment.id}>{trigger}</PaymentMenu>
+        ) : (
+          <TransactionMenu id={transaction.id}>{trigger}</TransactionMenu>
+        );
       },
-      {
-        id: "date",
-        header: "Datum",
-        accessorFn: (row) => row.transaction.effectiveDate,
-        cell: ({ row }) => (
-          <time dateTime={row.original.transaction.effectiveDate} className="text-sm font-medium text-neutral-12">
-            {numericDateFormatter.format(new Date(row.original.transaction.effectiveDate))}
-          </time>
-        ),
-      },
-      {
-        id: "description",
-        header: "Popis",
-        cell: ({ row }) => {
-          const { posting, transaction, payment } = row.original;
-          const description = transaction.description || describePosting(payment ?? undefined, posting);
-          return <span className="text-sm text-neutral-12">{description}</span>;
-        },
-      },
-      {
-        id: "amount",
-        header: "Částka",
-        cell: ({ row }) => (
-          <div className="text-right text-sm font-semibold text-neutral-12">
-            {moneyFormatter.format({ amount: row.original.posting.amount, currency })}
-          </div>
-        ),
-      },
-    ],
-    [currency]
-  );
+    },
+    {
+      accessorFn: (row) => row.transaction.effectiveDate,
+      header: "Datum",
+      cell: ({ row }) => (
+        <time dateTime={row.original.transaction.effectiveDate} className="text-sm font-medium text-neutral-12">
+          {numericDateFormatter.format(new Date(row.original.transaction.effectiveDate))}
+        </time>
+      ),
+    },
+    {
+      id: "description",
+      header: "Popis",
+      cell: ({ row }) => (
+        <span className="text-sm text-neutral-12">
+          {row.original.transaction.description ||
+            describePosting(row.original.transaction.payment ?? undefined, row.original)}
+        </span>
+      ),
+    },
+    {
+      id: "amount",
+      header: "Částka",
+      cell: ({ row }) => (
+        <div className="text-right text-sm font-semibold text-neutral-12">
+          {moneyFormatter.format({ amount: row.original.amount, currency })}
+        </div>
+      ),
+    },
+  ];
 
   if (rows.length === 0) {
-    return <p className="text-sm text-neutral-11">Žádné pohyby.</p>;
+    return <p>Žádné pohyby.</p>;
   }
 
   return (

--- a/frontend/ui/PersonPaymentsView.tsx
+++ b/frontend/ui/PersonPaymentsView.tsx
@@ -1,5 +1,7 @@
-import { PersonPaymentsDocument } from "@/graphql/Person";
+import { PersonPaymentsDocument, type PersonPaymentsQuery } from "@/graphql/Person";
 import React from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/ui/DataTable";
 import { describePosting, fullDateFormatter, moneyFormatter, numericDateFormatter } from "@/ui/format";
 import { useMutation, useQuery } from "urql";
 import { QRPayment } from "@/ui/QRPayment";
@@ -24,49 +26,65 @@ export function PersonPaymentsView({ id }: { id: string }) {
     return null;
   }
 
-  return (
-    <div className="prose prose-accent mb-2">
-      {person.unpaidPayments.length > 0 && <h3>K zaplacení</h3>}
-      {person.unpaidPayments.map(x => (
-        <div key={x.id}>
-          {x.payment?.cohortSubscription && (
-            <h4>Členské příspěvky {x.payment.cohortSubscription.cohort?.name}</h4>
-          )}
-          <dl className="not-prose mb-2">
-            <dt>Částka</dt>
-            <dd>
-              {moneyFormatter.format(x.price)}
-            </dd>
-            <dt>Účet</dt>
-            <dd>1806875329/0800</dd>
-            <dt>Variabilní symbol</dt>
-            <dd>{x.payment?.variableSymbol}</dd>
-            <dt>Specifický symbol</dt>
-            <dd>{x.payment?.specificSymbol}</dd>
-            <dt>Zpráva</dt>
-            <dd>{person.firstName} {person.lastName}, {x.payment?.cohortSubscription?.cohort?.name}</dd>
-            {x.payment?.dueAt && (
-              <>
-                <dt>Splatnost</dt>
-                <dd>{fullDateFormatter.format(new Date(x.payment?.dueAt))}</dd>
-              </>
-            )}
-          </dl>
+  const accounts = (person.accountsList ?? []).filter(Boolean) as Account[];
 
-          {tenant?.bankAccount && x.price?.amount && (
-            <div className="border-4 border-transparent dark:border-white w-fit">
-              <QRPayment
-                acc={tenant.bankAccount}
-                am={x.price.amount}
-                cc={x.price.currency || 'CZK'}
-                ss={x.payment?.specificSymbol}
-                vs={x.payment?.variableSymbol}
-                msg={`${person.firstName} ${person.lastName}, ${x.payment?.cohortSubscription?.cohort?.name}`}
-              />
+  return (
+    <div className="space-y-8">
+      {person.unpaidPayments.length > 0 && (
+        <div className="prose prose-accent space-y-4">
+          <h3>K zaplacení</h3>
+          {person.unpaidPayments.map((x) => (
+            <div key={x.id} className="space-y-3 rounded-xl border border-neutral-6 bg-neutral-1/80 p-4">
+              {x.payment?.cohortSubscription && (
+                <h4>Členské příspěvky {x.payment.cohortSubscription.cohort?.name}</h4>
+              )}
+              <dl className="not-prose grid grid-cols-1 gap-1 sm:grid-cols-2">
+                <div>
+                  <dt>Částka</dt>
+                  <dd>{moneyFormatter.format(x.price)}</dd>
+                </div>
+                <div>
+                  <dt>Účet</dt>
+                  <dd>1806875329/0800</dd>
+                </div>
+                <div>
+                  <dt>Variabilní symbol</dt>
+                  <dd>{x.payment?.variableSymbol}</dd>
+                </div>
+                <div>
+                  <dt>Specifický symbol</dt>
+                  <dd>{x.payment?.specificSymbol}</dd>
+                </div>
+                <div className="sm:col-span-2">
+                  <dt>Zpráva</dt>
+                  <dd>
+                    {person.firstName} {person.lastName}, {x.payment?.cohortSubscription?.cohort?.name}
+                  </dd>
+                </div>
+                {x.payment?.dueAt && (
+                  <div>
+                    <dt>Splatnost</dt>
+                    <dd>{fullDateFormatter.format(new Date(x.payment?.dueAt))}</dd>
+                  </div>
+                )}
+              </dl>
+
+              {tenant?.bankAccount && x.price?.amount && (
+                <div className="w-fit border-4 border-transparent dark:border-white">
+                  <QRPayment
+                    acc={tenant.bankAccount}
+                    am={x.price.amount}
+                    cc={x.price.currency || "CZK"}
+                    ss={x.payment?.specificSymbol}
+                    vs={x.payment?.variableSymbol}
+                    msg={`${person.firstName} ${person.lastName}, ${x.payment?.cohortSubscription?.cohort?.name}`}
+                  />
+                </div>
+              )}
             </div>
-          )}
+          ))}
         </div>
-      ))}
+      )}
 
       {auth.isAdmin && (
         <div className="flex gap-2">
@@ -78,55 +96,37 @@ export function PersonPaymentsView({ id }: { id: string }) {
           </Dialog>
         </div>
       )}
-      {person.accountsList.length === 0 && <p>Žádné evidované platby</p>}
-      {person.accountsList?.map(account => (
-        <div key={account.id}>
-          <div className="flex flex-wrap justify-between">
-            <div>Stav kreditu: {moneyFormatter.format({ amount: account.balance, currency: account.currency})}</div>
 
-            <div className="flex gap-2">
+      {accounts.length === 0 ? (
+        <p className="text-sm text-neutral-11">Žádné evidované platby</p>
+      ) : (
+        accounts.map((account) => (
+          <section key={account.id} className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="text-sm text-neutral-12">
+                Stav kreditu: {moneyFormatter.format({ amount: account.balance, currency: account.currency ?? "CZK" })}
+              </div>
               <button
                 type="button"
                 className={buttonCls()}
-                onClick={() => exportPostings(`${new Date().getFullYear()}-${new Date().getMonth()} ${person?.name}`, account.postingsList || [])}
+                onClick={() =>
+                  exportPostings(
+                    `${new Date().getFullYear()}-${new Date().getMonth()} ${person?.name}`,
+                    account.postingsList || []
+                  )
+                }
               >
                 Export XLSX
               </button>
             </div>
-          </div>
 
-          <div>
-            <h3>Minulé</h3>
-            {account.postingsList
-              .filter(keyIsNonNull('transaction'))
-              .sort((x, y) => y.transaction.effectiveDate.localeCompare(x.transaction.effectiveDate))
-              .map(posting => posting.transaction.payment ? (
-                <div key={posting.id} className="justify-between gap-2 flex flex-wrap">
-                  <PaymentMenu id={posting.transaction.payment.id}>
-                    <DropdownMenuTrigger.RowDots />
-                    <span>
-                      {numericDateFormatter.format(new Date(posting.transaction.effectiveDate))}{' '}
-                      {posting.transaction.description || describePosting(posting.transaction.payment, posting)}
-                    </span>
-                    <span>{moneyFormatter.format({ amount: posting.amount, currency: 'CZK' })}</span>
-                  </PaymentMenu>
-                </div>
-              ) : (
-                <div key={posting.id} className="justify-between gap-2 flex flex-wrap">
-                  <TransactionMenu id={posting.transaction.id}>
-                    <DropdownMenuTrigger.RowDots />
-                    <span>
-                      {numericDateFormatter.format(new Date(posting.transaction.effectiveDate))}{' '}
-                      {posting.transaction.description || describePosting(posting.transaction.payment, posting)}
-                    </span>
-                    <span>{moneyFormatter.format({ amount: posting.amount, currency: 'CZK' })}</span>
-                  </TransactionMenu>
-                </div>
-              )
-            )}
-          </div>
-        </div>
-      ))}
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold text-neutral-11">Minulé</h3>
+              <AccountPaymentsTable account={account} />
+            </div>
+          </section>
+        ))
+      )}
     </div>
   );
 }
@@ -143,5 +143,99 @@ function TransactionMenu({ id, children }: { id: string; children: React.ReactNo
         <DropdownMenuButton onClick={onDelete}>Smazat platbu</DropdownMenuButton>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+type Account = NonNullable<NonNullable<PersonPaymentsQuery["person"]>["accountsList"]>[number];
+type Posting = NonNullable<Account["postingsList"]>[number];
+type PostingRow = {
+  id: string;
+  posting: Posting;
+  transaction: NonNullable<Posting["transaction"]>;
+  payment: NonNullable<Posting["transaction"]>["payment"] | null;
+};
+
+function AccountPaymentsTable({ account }: { account: Account }) {
+  const rows = React.useMemo<PostingRow[]>(() => {
+    const list = (account.postingsList ?? []).filter(Boolean) as Posting[];
+    const filtered = list.filter(keyIsNonNull("transaction"));
+    return filtered
+      .sort((a, b) => b.transaction.effectiveDate.localeCompare(a.transaction.effectiveDate))
+      .map((posting) => {
+        const transaction = posting.transaction;
+        return {
+          id: posting.id,
+          posting,
+          transaction,
+          payment: transaction.payment,
+        } satisfies PostingRow;
+      });
+  }, [account.postingsList]);
+
+  const currency = account.currency ?? "CZK";
+
+  const columns = React.useMemo<ColumnDef<PostingRow, unknown>[]>(
+    () => [
+      {
+        id: "actions",
+        header: "",
+        size: 36,
+        enableSorting: false,
+        enableHiding: false,
+        cell: ({ row }) => {
+          const { payment, transaction } = row.original;
+          const trigger = <DropdownMenuTrigger.RowDots className="text-neutral-10 hover:text-neutral-12" />;
+          return payment ? (
+            <PaymentMenu id={payment.id}>{trigger}</PaymentMenu>
+          ) : (
+            <TransactionMenu id={transaction.id}>{trigger}</TransactionMenu>
+          );
+        },
+      },
+      {
+        id: "date",
+        header: "Datum",
+        accessorFn: (row) => row.transaction.effectiveDate,
+        cell: ({ row }) => (
+          <time dateTime={row.original.transaction.effectiveDate} className="text-sm font-medium text-neutral-12">
+            {numericDateFormatter.format(new Date(row.original.transaction.effectiveDate))}
+          </time>
+        ),
+      },
+      {
+        id: "description",
+        header: "Popis",
+        cell: ({ row }) => {
+          const { posting, transaction, payment } = row.original;
+          const description = transaction.description || describePosting(payment ?? undefined, posting);
+          return <span className="text-sm text-neutral-12">{description}</span>;
+        },
+      },
+      {
+        id: "amount",
+        header: "Částka",
+        cell: ({ row }) => (
+          <div className="text-right text-sm font-semibold text-neutral-12">
+            {moneyFormatter.format({ amount: row.original.posting.amount, currency })}
+          </div>
+        ),
+      },
+    ],
+    [currency]
+  );
+
+  if (rows.length === 0) {
+    return <p className="text-sm text-neutral-11">Žádné pohyby.</p>;
+  }
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      enableSelection={false}
+      enablePagination={false}
+      toolbar={() => null}
+      estimatedRowHeight={48}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- polish the shared DataTable with optional selection/pagination controls and lighter styling
- render the person payments history via the reusable DataTable without paging while keeping outstanding payment details

## Testing
- yarn workspace rozpisovnik-web lint

------
https://chatgpt.com/codex/tasks/task_e_68f02e1864488322b779bbaf20faf0af